### PR TITLE
fix(validateOptions): catch `ValidationError` and handle it internally

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint --cache src test",
     "lint-staged": "lint-staged",
     "security": "nsp check",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --collectCoverageFrom='src/**/*.js' --coverage",
+    "test": "cross-env JEST=true jest",
+    "test:watch": "cross-env JEST=true jest --watch",
+    "test:coverage": "cross-env JEST=true jest --collectCoverageFrom='src/**/*.js' --coverage",
     "travis:lint": "npm run lint && npm run security",
     "travis:test": "npm run test -- --runInBand",
     "travis:coverage": "npm run test:coverage -- --runInBand",
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "ajv": "^5.0.0",
-    "ajv-keywords": "^2.1.0"
+    "ajv-keywords": "^2.1.0",
+    "chalk": "^2.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.0.0",

--- a/src/ValidationError.js
+++ b/src/ValidationError.js
@@ -4,7 +4,7 @@ class ValidationError extends Error {
 
     this.name = 'ValidationError';
 
-    this.message = `Validation Error\n\n${name || ''} Invalid Options\n\n`;
+    this.message = `${name || ''} Invalid Options\n\n`;
 
     errors.forEach((err) => {
       this.message += `options${err.dataPath} ${err.message}\n`;

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -1,21 +1,25 @@
 /* eslint-disable
   import/order,
-  no-param-reassign
+  no-param-reassign,
+  array-bracket-spacing,
 */
 import fs from 'fs';
 import path from 'path';
 
+import chalk from 'chalk';
+
 import Ajv from 'ajv';
 import ajvKeywords from 'ajv-keywords';
+
 import ValidationError from './ValidationError';
 
 const ajv = new Ajv({
-  useDefaults: true,
   allErrors: true,
+  useDefaults: true,
   errorDataPath: 'property',
 });
 
-ajvKeywords(ajv, ['instanceof', 'typeof']);
+ajvKeywords(ajv, [ 'instanceof', 'typeof' ]);
 
 const validateOptions = (schema, options, name) => {
   if (typeof schema === 'string') {
@@ -24,7 +28,18 @@ const validateOptions = (schema, options, name) => {
   }
 
   if (!ajv.validate(schema, options)) {
-    throw new ValidationError(ajv.errors, name);
+    try {
+      throw new ValidationError(ajv.errors, name);
+    } catch (err) {
+      console.error(chalk.bold.red(`\n${err.message}\n`));
+
+      // rethrow {Error} for testing only
+      if (process.env.JEST) {
+        throw err;
+      }
+
+      process.exit(1);
+    }
   }
 
   return true;

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Error should have errors for every key in options 1`] = `
+exports[`Error should have errors for every option key 1`] = `
 Array [
   Object {
     "dataPath": ".string",
@@ -30,6 +30,15 @@ Array [
     "schemaPath": "#/properties/object/properties/prop/type",
   },
   Object {
+    "dataPath": ".object.object.prop",
+    "keyword": "type",
+    "message": "should be boolean",
+    "params": Object {
+      "type": "boolean",
+    },
+    "schemaPath": "#/properties/object/properties/object/properties/prop/type",
+  },
+  Object {
     "dataPath": ".boolean",
     "keyword": "type",
     "message": "should be boolean",
@@ -57,4 +66,17 @@ Array [
     "schemaPath": "#/properties/instance/instanceof",
   },
 ]
+`;
+
+exports[`Error should throw error 1`] = `
+"{Name} Invalid Options
+
+options.string should be string
+options.array should be array
+options.object.prop should be boolean
+options.object.object.prop should be boolean
+options.boolean should be boolean
+options.type should pass \\"typeof\\" keyword validation
+options.instance should pass \\"instanceof\\" keyword validation
+"
 `;

--- a/test/fixtures/schema.json
+++ b/test/fixtures/schema.json
@@ -15,6 +15,14 @@
       "properties": {
         "prop": {
           "type": "boolean"
+        },
+        "object": {
+          "type": "object",
+          "properties": {
+            "prop": {
+              "type": "boolean"
+            }
+          }
         }
       }
     },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,11 +7,16 @@ import validateOptions from '../src';
 
 test('Valid', () => {
   const options = {
-    string: 'hello',
-    array: [ 'a' ],
-    object: { prop: false },
-    boolean: true,
     type() {},
+    array: [ 'a' ],
+    string: 'hello',
+    object: {
+      prop: false,
+      object: {
+        prop: false
+      }
+    },
+    boolean: true,
     instance: new RegExp('')
   };
 
@@ -21,11 +26,16 @@ test('Valid', () => {
 
 describe('Error', () => {
   const options = {
-    string: false,
-    array: {},
-    object: { prop: 1 },
-    boolean: 'hello',
     type: null,
+    array: {},
+    string: false,
+    object: {
+      prop: 1,
+      object: {
+        prop: 1
+      }
+    },
+    boolean: 'hello',
     instance() {}
   };
 
@@ -34,16 +44,25 @@ describe('Error', () => {
   };
 
   test('should throw error', () => {
-    expect(validate).toThrowError(/Validation Error\n\n{Name} Invalid Options\n\n/);
+    expect(validate).toThrowError();
+    expect(validate).toThrowErrorMatchingSnapshot();
   });
 
-  test('should have errors for every key in options', () => {
+  test('should have errors for every option key', () => {
     try {
       validate();
     } catch (err) {
-      const errors = err.errors.map(e => e.dataPath);
+      const errors = err.errors.map(err => err.dataPath);
 
-      const expected = ['.string', '.array', '.object.prop', '.boolean', '.type', '.instance'];
+      const expected = [
+        '.string',
+        '.array',
+        '.object.prop',
+        '.object.object.prop',
+        '.boolean',
+        '.type',
+        '.instance'
+      ];
 
       expect(errors).toMatchObject(expected);
       expect(err.errors).toMatchSnapshot();


### PR DESCRIPTION
### `Noteable Changes`

- catches the `ValidationError`, displays the `err.message` without any clutter (especially for plugins) && avoids duplicated messages for loaders since the `{Error}` won't bubble up anymore
  