### PR TITLE
fix(ValidationError): never return `this` in the ctor

### DIFF
--- a/src/ValidationError.js
+++ b/src/ValidationError.js
@@ -13,8 +13,6 @@ class ValidationError extends Error {
     this.errors = errors;
 
     Error.captureStackTrace(this, this.constructor);
-
-    return this;
   }
 }
 


### PR DESCRIPTION
### `Notable Changes`

- Don't return `this` in the ctor so the `err.stack` and stack capturing (`Error.captureStackTrace`) works correctly and can be handled by `webpack` itself ([#5892](https://github.com/webpack/webpack/pull/5892))

### `Blocked by`

- ~~[`webpack@next` (#5892)](https://github.com/webpack/webpack/pull/5892)~~
- ~~[`webpack` (#6035)](https://github.com/webpack/webpack/pull/6035)~~

### `Issues`

- None