### PR TITLE
fix(src): `node >= v4.0.0` support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jobs:
       node_js: 'lts/*'
     - <<: *test
       node_js: 6
+    - <<: *test
+      node_js: 4
 
 script: npm run $SCRIPT
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "eslint": "^5.0.0",
     "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-prettier": "^2.0.0",
-    "jest": "^22.0.0",
+    "jest": "^21.0.0",
     "prettier": "^1.0.0",
     "standard-version": "^4.0.0"
   },

--- a/src/ValidationError.js
+++ b/src/ValidationError.js
@@ -1,3 +1,9 @@
+/* eslint-disable
+  strict
+*/
+
+'use strict';
+
 class ValidationError extends Error {
   constructor(errors, name) {
     super();

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,9 @@
+/* eslint-disable
+  strict
+*/
+
+'use strict';
+
 const validateOptions = require('./validateOptions');
 
 module.exports = validateOptions;

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -1,6 +1,10 @@
 /* eslint-disable
+  strict,
   no-param-reassign
 */
+
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,10 @@
 /* eslint-disable
+  strict,
   no-shadow
 */
+
+'use strict';
+
 const validateOptions = require('../src');
 
 test('Valid', () => {


### PR DESCRIPTION
### Notable Changes

Fixes support for `node` v4.0.0 by adding `'use strict';` directives to the code base

### Type

- [x] Fix

### Issues

- Fixes #31 

### SemVer

- [x] Fix (:label: Patch)

### Checklist

- [x] I have signed the CLA
- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works (if needed)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules
