### PR TITLE
feat(src): add support for custom error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,32 @@ npm i schema-utils
 
 ### `validateOptions`
 
-**schema.json**
+**`schema.json`**
 ```js
 {
   "type": "object",
   "properties": {
     // Options...
   },
+  "additionalProperties": false
+}
+```
+
+#### Error Messages (Custom)
+
+**`schema.json`**
+```js
+{
+  "type": "object",
+  "properties": {
+    "option": {
+      "type": [ "boolean" ]
+    }
+  },
+  // Overrides the default err.message for option
+  "errorMessage": {
+    "option": "should be {Boolean} (https:/github.com/org/repo#anchor)"
+  }
   "additionalProperties": false
 }
 ```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "ajv": "^6.1.0",
+    "ajv-errors": "^1.0.0",
     "ajv-keywords": "^3.1.0"
   },
   "devDependencies": {

--- a/src/ValidationError.js
+++ b/src/ValidationError.js
@@ -1,5 +1,6 @@
 /* eslint-disable
-  strict
+  strict,
+  no-param-reassign
 */
 
 'use strict';
@@ -12,11 +13,15 @@ class ValidationError extends Error {
 
     this.message = `${name || ''} Invalid Options\n\n`;
 
-    errors.forEach((err) => {
-      this.message += `options${err.dataPath} ${err.message}\n`;
+    this.errors = errors.map((err) => {
+      err.dataPath = err.dataPath.replace(/\//g, '.');
+
+      return err;
     });
 
-    this.errors = errors;
+    this.errors.forEach((err) => {
+      this.message += `options${err.dataPath} ${err.message}\n`;
+    });
 
     Error.captureStackTrace(this, this.constructor);
   }

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -9,17 +9,18 @@ const fs = require('fs');
 const path = require('path');
 
 const Ajv = require('ajv');
-const ajvKeywords = require('ajv-keywords');
+const errors = require('ajv-errors');
+const keywords = require('ajv-keywords');
 
 const ValidationError = require('./ValidationError');
 
 const ajv = new Ajv({
   allErrors: true,
-  useDefaults: true,
-  errorDataPath: 'property',
+  jsonPointers: true,
 });
 
-ajvKeywords(ajv, ['instanceof', 'typeof']);
+errors(ajv);
+keywords(ajv, ['instanceof', 'typeof']);
 
 const validateOptions = (schema, options, name) => {
   if (typeof schema === 'string') {

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Error should have errors for every option key 1`] = `
+exports[`Error Errors 1`] = `
 Array [
   Object {
     "dataPath": ".string",
@@ -68,7 +68,55 @@ Array [
 ]
 `;
 
-exports[`Error should throw error 1`] = `
+exports[`Error Messages Customized 1`] = `
+Object {
+  "dataPath": ".string",
+  "keyword": "errorMessage",
+  "message": "should be {String} (https://github.com/org/repo#anchor)",
+  "params": Object {
+    "errors": Array [
+      Object {
+        "dataPath": "/string",
+        "keyword": "type",
+        "message": "should be string",
+        "params": Object {
+          "type": "string",
+        },
+        "schemaPath": "#/properties/string/type",
+      },
+    ],
+  },
+  "schemaPath": "#/errorMessage",
+}
+`;
+
+exports[`Error Messages Customized 2`] = `
+"{Name} Invalid Options
+
+options.string should be {String} (https://github.com/org/repo#anchor)
+"
+`;
+
+exports[`Error Messages Default 1`] = `
+Object {
+  "dataPath": ".string",
+  "keyword": "type",
+  "message": "should be string",
+  "params": Object {
+    "type": "string",
+  },
+  "schemaPath": "#/properties/string/type",
+}
+`;
+
+exports[`Error Messages Default 2`] = `
+"{Name} Invalid Options
+
+options.string should be string
+"
+`;
+
+exports[`Error Throws 1`] = `
 "{Name} Invalid Options
 
 options.string should be string

--- a/test/fixtures/errors/schema.json
+++ b/test/fixtures/errors/schema.json
@@ -1,0 +1,61 @@
+{
+  "type": "object",
+  "properties": {
+    "string": {
+      "type": "string"
+    },
+    "array": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "object": {
+      "type": "object",
+      "properties": {
+        "prop": {
+          "type": "boolean"
+        },
+        "object": {
+          "type": "object",
+          "properties": {
+            "prop": {
+              "type": "boolean"
+            }
+          },
+          "errorMessage": {
+            "properties": {
+              "prop": "should be {Boolean} (https://github.com/org/repo#anchor)"
+            }
+          }
+        }
+      },
+      "errorMessage": {
+        "properties": {
+          "prop": "should be {Boolean} (https://github.com/org/repo#anchor)",
+          "object": "should be {Object} (https://github.com/org/repo#anchor)"
+        }
+      }
+    },
+    "boolean": {
+      "type": "boolean"
+    },
+    "type": {
+      "typeof": "function"
+    },
+    "instance": {
+      "instanceof": "RegExp"
+    }
+  },
+  "errorMessage": {
+    "properties": {
+      "type": "should be {Function} (https://github.com/org/repo#anchor)",
+      "array": "should be {Array} (https://github.com/org/repo#anchor)",
+      "string": "should be {String} (https://github.com/org/repo#anchor)",
+      "object": "should be {Object} (https://github.com/org/repo#anchor)",
+      "boolean": "should be {Boolean} (https://github.com/org/repo#anchor)",
+      "instance": "should be {RegExp} (https://github.com/org/repo#anchor)"
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable
   strict,
-  no-shadow
+  no-shadow,
+  arrow-body-style
 */
 
 'use strict';
@@ -21,10 +22,11 @@ test('Valid', () => {
     boolean: true,
     instance: new RegExp(''),
   };
+  const validate = () => {
+    return validateOptions('test/fixtures/schema.json', options, '{Name}');
+  };
 
-  expect(validateOptions('test/fixtures/schema.json', options, 'Loader')).toBe(
-    true
-  );
+  expect(validate()).toBe(true);
 });
 
 describe('Error', () => {
@@ -42,15 +44,16 @@ describe('Error', () => {
     instance() {},
   };
 
-  const validate = () =>
-    validateOptions('test/fixtures/schema.json', options, '{Name}');
+  const validate = () => {
+    return validateOptions('test/fixtures/schema.json', options, '{Name}');
+  };
 
-  test('should throw error', () => {
+  test('Throws', () => {
     expect(validate).toThrowError();
     expect(validate).toThrowErrorMatchingSnapshot();
   });
 
-  test('should have errors for every option key', () => {
+  test('Errors', () => {
     try {
       validate();
     } catch (err) {
@@ -69,5 +72,67 @@ describe('Error', () => {
       expect(errors).toMatchObject(expected);
       expect(err.errors).toMatchSnapshot();
     }
+  });
+
+  describe('Messages', () => {
+    test('Default', () => {
+      const options = {
+        type() {},
+        array: [''],
+        string: 1,
+        object: {
+          prop: false,
+          object: {
+            prop: false,
+          },
+        },
+        boolean: true,
+        instance: new RegExp(''),
+      };
+
+      const validate = () => {
+        return validateOptions('test/fixtures/schema.json', options, '{Name}');
+      };
+
+      try {
+        validate();
+      } catch (err) {
+        err.errors.forEach((err) => expect(err).toMatchSnapshot());
+
+        expect(err.message).toMatchSnapshot();
+      }
+    });
+
+    test('Customized', () => {
+      const options = {
+        type() {},
+        array: [''],
+        string: 1,
+        object: {
+          prop: false,
+          object: {
+            prop: false,
+          },
+        },
+        boolean: true,
+        instance: new RegExp(''),
+      };
+
+      const validate = () => {
+        return validateOptions(
+          'test/fixtures/errors/schema.json',
+          options,
+          '{Name}'
+        );
+      };
+
+      try {
+        validate();
+      } catch (err) {
+        err.errors.forEach((err) => expect(err).toMatchSnapshot());
+
+        expect(err.message).toMatchSnapshot();
+      }
+    });
   });
 });


### PR DESCRIPTION
### Notable Changes

This PR adds support for custom error messages defined in the options schema within an `errorMessage`  property. Current schemas without an `errorMessage` prop are unaffected by this change

**`schema.json`**
```js
{
  "type": "object",
  "properties": {
    "option": {
      "type": [ "boolean" ]
    }
  },
  // Overrides the default err.message for option
  "errorMessage": {
    "option": "should be {Boolean} (https:/github.com/org/repo#anchor)"
  }
  "additionalProperties": false
}
```

```diff
{Name} Invalid Options

- options.option should be boolean
+ options.option should be {Boolean} (https:/github.com/org/repo#anchor)
```

### Type

- [x] Feature

### Issues

- Fixes #18

### SemVer

- [x] Feature (:label: Minor)

### Checklist

- [x] I have signed the CLA
- [x] Lint and unit tests pass with my changes
- [x] I have added tests that prove my fix is effective/works (if needed)
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes are merged and published in downstream modules
