### PR TITLE
weak memoize passed validateOptions(), drop support for schema as str

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm i schema-utils
 
 ### `validateOptions`
 
+**Note:** Validations are cached using the object indentity of `schema` & `options` arguments. For this reason, it is recommended to never mutate the options & schema objects after being validated.
+
 **`schema.json`**
 ```js
 {

--- a/src/ajv.js
+++ b/src/ajv.js
@@ -1,0 +1,12 @@
+const Ajv = require('ajv');
+const errors = require('ajv-errors');
+const keywords = require('ajv-keywords');
+
+const ajv = new Ajv({
+  allErrors: true,
+  jsonPointers: true,
+});
+errors(ajv);
+keywords(ajv, ['instanceof', 'typeof']);
+
+module.exports = ajv;

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -5,9 +5,6 @@
 
 'use strict';
 
-const fs = require('fs');
-const path = require('path');
-
 const Ajv = require('ajv');
 const errors = require('ajv-errors');
 const keywords = require('ajv-keywords');
@@ -25,33 +22,22 @@ keywords(ajv, ['instanceof', 'typeof']);
 const passedBySchema = new WeakMap();
 
 const validateOptions = (schema, options, name) => {
-  if (typeof schema === 'string') {
-    if (
-      !ajv.validate(
-        JSON.parse(fs.readFileSync(path.resolve(schema), 'utf8')),
-        options
-      )
-    ) {
-      throw new ValidationError(ajv.errors, name);
-    }
-  } else {
-    const passed = passedBySchema.get(schema);
+  const passed = passedBySchema.get(schema);
 
-    if (passed) {
-      if (!passed.has(options)) {
-        if (!ajv.validate(schema, options)) {
-          throw new ValidationError(ajv.errors, name);
-        }
-
-        passed.add(options);
-      }
-    } else {
+  if (passed) {
+    if (!passed.has(options)) {
       if (!ajv.validate(schema, options)) {
         throw new ValidationError(ajv.errors, name);
       }
 
-      passedBySchema.set(schema, new WeakSet([options]));
+      passed.add(options);
     }
+  } else {
+    if (!ajv.validate(schema, options)) {
+      throw new ValidationError(ajv.errors, name);
+    }
+
+    passedBySchema.set(schema, new WeakSet([options]));
   }
 
   return true;

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -5,19 +5,8 @@
 
 'use strict';
 
-const Ajv = require('ajv');
-const errors = require('ajv-errors');
-const keywords = require('ajv-keywords');
-
 const ValidationError = require('./ValidationError');
-
-const ajv = new Ajv({
-  allErrors: true,
-  jsonPointers: true,
-});
-
-errors(ajv);
-keywords(ajv, ['instanceof', 'typeof']);
+const ajv = require('./ajv');
 
 const passedBySchema = new WeakMap();
 
@@ -44,4 +33,3 @@ const validateOptions = (schema, options, name) => {
 };
 
 module.exports = validateOptions;
-module.exports.ajv = ajv;

--- a/src/validateOptions.js
+++ b/src/validateOptions.js
@@ -22,14 +22,20 @@ const ajv = new Ajv({
 errors(ajv);
 keywords(ajv, ['instanceof', 'typeof']);
 
-const validateOptions = (schema, options, name) => {
-  if (typeof schema === 'string') {
-    schema = fs.readFileSync(path.resolve(schema), 'utf8');
-    schema = JSON.parse(schema);
-  }
+const passed = new WeakSet();
 
-  if (!ajv.validate(schema, options)) {
-    throw new ValidationError(ajv.errors, name);
+const validateOptions = (schema, options, name) => {
+  if (!passed.has(options)) {
+    if (typeof schema === 'string') {
+      schema = fs.readFileSync(path.resolve(schema), 'utf8');
+      schema = JSON.parse(schema);
+    }
+
+    if (!ajv.validate(schema, options)) {
+      throw new ValidationError(ajv.errors, name);
+    }
+
+    passed.add(options);
   }
 
   return true;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,20 +26,30 @@ const validOptions = Object.freeze({
   instance: new RegExp(''),
 });
 
-describe('Valid', () => {
-  describe('when schema is object', () => {
-    test('should pass, uncached', () => {
-      const validateSpy = jest.spyOn(ajv, 'validate');
-      expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
-      expect(validateSpy).toHaveBeenCalled();
-      validateSpy.mockRestore();
-    });
-    test('should pass, cached', () => {
-      const validateSpy = jest.spyOn(ajv, 'validate');
-      expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
-      expect(validateSpy).not.toHaveBeenCalled();
-      validateSpy.mockRestore();
-    });
+describe('when schema is object', () => {
+  test('should pass, uncached', () => {
+    const validateSpy = jest.spyOn(ajv, 'validate');
+    expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
+    expect(validateSpy).toHaveBeenCalled();
+    validateSpy.mockRestore();
+  });
+  test('should pass, cached', () => {
+    const validateSpy = jest.spyOn(ajv, 'validate');
+    expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
+    expect(validateSpy).not.toHaveBeenCalled();
+    validateSpy.mockRestore();
+  });
+});
+
+describe('when schema is string', () => {
+  test('should throw', () => {
+    expect(() => {
+      return validateOptions(
+        'test/fixtured/schema.json',
+        validOptions,
+        '{Name}'
+      );
+    }).toThrowError('no schema with key or ref "test/fixtured/schema.json"');
   });
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const ajv = require('../src/ajv');
 const validateOptions = require('../src');
 
 const testSchema = require('./fixtures/schema.json');
@@ -28,13 +29,13 @@ const validOptions = Object.freeze({
 describe('Valid', () => {
   describe('when schema is object', () => {
     test('should pass, uncached', () => {
-      const validateSpy = jest.spyOn(validateOptions.ajv, 'validate');
+      const validateSpy = jest.spyOn(ajv, 'validate');
       expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
       expect(validateSpy).toHaveBeenCalled();
       validateSpy.mockRestore();
     });
     test('should pass, cached', () => {
-      const validateSpy = jest.spyOn(validateOptions.ajv, 'validate');
+      const validateSpy = jest.spyOn(ajv, 'validate');
       expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
       expect(validateSpy).not.toHaveBeenCalled();
       validateSpy.mockRestore();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,8 +6,6 @@
 
 'use strict';
 
-const fs = require('fs');
-
 const validateOptions = require('../src');
 
 const testSchema = require('./fixtures/schema.json');
@@ -30,38 +28,15 @@ const validOptions = Object.freeze({
 describe('Valid', () => {
   describe('when schema is object', () => {
     test('should pass, uncached', () => {
-      const readFileSpy = jest.spyOn(fs, 'readFileSync');
       const validateSpy = jest.spyOn(validateOptions.ajv, 'validate');
       expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
       expect(validateSpy).toHaveBeenCalled();
-      expect(readFileSpy).not.toHaveBeenCalled();
-      readFileSpy.mockRestore();
       validateSpy.mockRestore();
     });
     test('should pass, cached', () => {
-      const readFileSpy = jest.spyOn(fs, 'readFileSync');
       const validateSpy = jest.spyOn(validateOptions.ajv, 'validate');
       expect(validateOptions(testSchema, validOptions, '{Name}')).toBe(true);
       expect(validateSpy).not.toHaveBeenCalled();
-      expect(readFileSpy).not.toHaveBeenCalled();
-      readFileSpy.mockRestore();
-      validateSpy.mockRestore();
-    });
-  });
-
-  describe('when schema is string', () => {
-    test('should pass, uncached', () => {
-      const readFileSpy = jest.spyOn(fs, 'readFileSync');
-      const validateSpy = jest.spyOn(validateOptions.ajv, 'validate');
-      expect(
-        validateOptions('test/fixtures/schema.json', validOptions, '{Name}')
-      ).toBe(true);
-      expect(
-        validateOptions('test/fixtures/schema.json', validOptions, '{Name}')
-      ).toBe(true);
-      expect(validateSpy).toHaveBeenCalledTimes(2);
-      expect(readFileSpy).toHaveBeenCalledTimes(2);
-      readFileSpy.mockRestore();
       validateSpy.mockRestore();
     });
   });


### PR DESCRIPTION
### Notable Changes

This change aims to reduce extraneous runs of `validateOptions()`. I believe this will be especially beneficial to loaders. For ex: https://github.com/webpack-contrib/style-loader/blob/master/index.js#L17.

**Update:** This pr includes a breaking change. However, since `schema-utils` is primarily used for core webpack libs - this should allow consumers to avoid major bump, since its impl is entirely internal.

#### `Commit Message Summary (CHANGELOG)`

```bash
PERF: weak memoize passed `validateOptions()`
BREAKING CHANGE: drop support for typeof schema === 'string'
```

### Type

- [X] Perf

### Issues

N/A

### SemVer

- [X] Breaking Change (:label: Major)

### Checklist

- [X] I have signed the CLA
- [X] Lint and unit tests pass with my changes
- [X] I have added tests that prove my fix is effective/works (if needed)
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes are merged and published in downstream modules - N/A
    